### PR TITLE
Support parsing double serialized data

### DIFF
--- a/laravel_session.go
+++ b/laravel_session.go
@@ -79,5 +79,13 @@ func ParseSessionData(data string) (php_serialize.PhpArray, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Some cache-based session stores such as redis result in double
+	// serialization of session data. If the session data is a string
+	// then this has almost certainly happened.
+	if sessionDataDecodedString, ok := sessionDataDecoded.(string); ok {
+		return ParseSessionData(sessionDataDecodedString)
+	}
+
 	return sessionDataDecoded.(php_serialize.PhpArray), nil
 }

--- a/laravel_session_test.go
+++ b/laravel_session_test.go
@@ -52,3 +52,18 @@ func TestParseSessionData(t *testing.T) {
 		t.Error("fail")
 	}
 }
+
+func TestParseSessionDataWithDoubleSerialization(t *testing.T) {
+	sessionData := `s:267:"a:5:{s:6:"_token";s:40:"eE5gVNqGSn6wneCJAzhtTMulPFwvOfDyZRSoVStA";s:3:"url";a:0:{}s:9:"_previous";a:1:{s:3:"url";s:29:"https://jshb-admin.dev/update";}s:6:"_flash";a:2:{s:3:"old";a:0:{}s:3:"new";a:0:{}}s:52:"login_admin_59ba36addc2b2f9401580f014c7f58ea4e30989d";i:1;}";`
+	session, err := ParseSessionData(sessionData)
+
+	if err != nil {
+		t.Errorf("fail - %s", err)
+	}
+
+	if session["_token"].(string) == "eE5gVNqGSn6wneCJAzhtTMulPFwvOfDyZRSoVStA" {
+		t.Log("ok")
+	} else {
+		t.Error("fail")
+	}
+}


### PR DESCRIPTION
This occurs when using Redis to store session data